### PR TITLE
feat: add importable workflows for flutter projects

### DIFF
--- a/.github/workflows/check_flutter.yaml
+++ b/.github/workflows/check_flutter.yaml
@@ -1,0 +1,29 @@
+name: check
+on:
+  workflow_call:
+jobs:
+  wiz-scan:
+    uses: affinidi/pipeline-security/.github/workflows/wizcli-dirscan.yml@main
+    secrets: inherit
+  build:
+    runs-on: ubuntu-latest
+    services:
+      localstack:
+        image: localstack/localstack:latest
+        ports:
+          - 4566:4566
+        options: --env KMS=true
+
+    steps:
+      - uses: actions/checkout@v4
+      # Note: This workflow uses the latest stable version of the Fluter+Dart SDK.
+      # You can specify other versions if desired, see documentation here:
+      # https://github.com/flutter-actions/setup-flutter/blob/main/README.md
+      - uses: flutter-actions/setup-flutter@v3
+      - uses: bluefireteam/melos-action@v3
+      - run: melos format --output=none --set-exit-if-changed .
+      - run: melos analyze
+      - run: melos test
+      - uses: romeovs/lcov-reporter-action@v0.3.1
+        with:
+          lcov-file: ./coverage/lcov.info

--- a/.github/workflows/publish_flutter.yaml
+++ b/.github/workflows/publish_flutter.yaml
@@ -1,0 +1,27 @@
+name: publish
+
+
+on:
+  workflow_call:
+    inputs:
+      publish: 
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  publish-packages:
+    name: Publish packages
+    environment: release
+    permissions:
+      contents: write
+      id-token: write # Required for authentication using OIDC
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: flutter-actions/setup-flutter@v3
+      - uses: bluefireteam/melos-action@v3
+        with:
+          publish: ${{ inputs.publish }}

--- a/.github/workflows/release_flutter.yaml
+++ b/.github/workflows/release_flutter.yaml
@@ -1,0 +1,41 @@
+name: release
+on:
+  workflow_call:
+jobs:
+  wiz-scan:
+    uses: affinidi/pipeline-security/.github/workflows/wizcli-dirscan.yml@main
+    secrets: inherit
+  build:
+    runs-on: ubuntu-latest
+    environment: main
+    concurrency: release
+    if: ${{ !contains(github.event.head_commit.message, 'chore(release)') }}
+    steps:
+      - name: Generate token from app token #https://github.com/tibdex/github-app-token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private_key: ${{ secrets.RELEASE_BOT_PKEY }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
+      - name: configure git
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+      # Note: This workflow uses the latest stable version of the Flutter+Dart SDK.
+      # You can specify other versions if desired, see documentation here:
+      # https://github.com/flutter-actions/setup-flutter/blob/main/README.md
+      - uses: flutter-actions/setup-flutter@v3
+      - uses: bluefireteam/melos-action@v3
+        with:
+          run-versioning: true
+          publish-dry-run: true
+          tag: true
+          create-pr: false
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+      - name: Push Tags
+        run: git push --follow-tags

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Pipeline-dart
 
 pipeline for Affinidi dart projects
+NB: if your project contains at least one flutter package, use `workflow_flutter.yaml`, otherwise `workflow.yaml` to save time and resources.
 
 ## How to use
 
@@ -14,7 +15,7 @@ on:
      
 jobs:
   dart-pipeline:
-    uses: affinidi/pipeline-dart/.github/workflows/check.yaml@main
+    uses: affinidi/pipeline-dart/.github/workflows/check{_flutter}.yaml@main
     secrets: inherit
 ```
 
@@ -30,7 +31,7 @@ on:
 
 jobs:
   dart-pipeline:
-    uses: affinidi/pipeline-dart/.github/workflows/release.yaml@main
+    uses: affinidi/pipeline-dart/.github/workflows/release{_flutter}.yaml@main
     secrets: inherit
 ```
 
@@ -47,6 +48,6 @@ on:
 
 jobs:
   dart-pipeline:
-    uses: affinidi/pipeline-dart/.github/workflows/publish.yaml@main
+    uses: affinidi/pipeline-dart/.github/workflows/publish{_flutter}.yaml@main
     secrets: inherit
 ```


### PR DESCRIPTION
For the projects containing flutter packages, setting up flutter SDK is required. I would like it a conditional within one workflow, but unfortunately, `uses` directive doesn't support conditionals, so moving it to the level of import.