### PR TITLE
fix: disable double dart setup by melos-action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,3 +33,4 @@ jobs:
       - uses: bluefireteam/melos-action@v3
         with:
           publish: ${{ inputs.publish }}
+          dart-version: 'none'


### PR DESCRIPTION
as per https://github.com/bluefireteam/melos-action/tree/v3.4.0 we can avoid repeating dart-setup and problems related to it