### PR TITLE
fix: updating action used for generating access token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,10 +30,10 @@ jobs:
     steps:
       - name: Generate token from app token #https://github.com/tibdex/github-app-token
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ secrets.RELEASE_BOT_APP_ID }}
-          private_key: ${{ secrets.RELEASE_BOT_PKEY }}
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PKEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -59,4 +59,3 @@ jobs:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
       - name: Push Tags
         run: git push --follow-tags
-        


### PR DESCRIPTION
This PR
- Updates the action to generate an app access token to https://github.com/actions/create-github-app-token as https://github.com/tibdex/github-app-token is archived